### PR TITLE
Switch to Nix for CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 # Python
 __pycache__
 *.egg-info
+
+/result

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,5 @@
-language: rust
-dist: xenial
-
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5-dev
-      - python3.6-dev
-      - python3.6-venv
-      - python3.7-dev
-
-matrix:
-  fast_finish: true
-  include:
-    - os: linux
-      rust: nightly-2019-05-04
-    - os: osx
-      osx_image: xcode10.1
-      rust: nightly-2019-05-04
-
-install:
-  - |
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      python3 -m venv venv
-      source venv/bin/activate
-      pip install cffi virtualenv pytest
-    fi
-  - |
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      python3.6 -m venv venv
-      source venv/bin/activate
-      pip install cffi virtualenv pytest
-    fi
-  - cargo install pyo3-pack --vers 0.6.1
-  - rustup default nightly-2019-05-04
-  - rustup component add rustfmt
-
-script:
-  - cargo fmt --all -- --check
-  - pyo3-pack develop
-  - pytest
+language: nix
+nix: 2.2.2
+before_script:
+  - sudo mkdir /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
+script: nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/31a6c5a7b507847221598b0d14dd41e935afea4e.tar.gz --expr 'with import <nixpkgs> {}; callPackage ./default.nix { releaseBuild = false; }'

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,56 @@
+{
+  callPackage
+, lib
+
+, nix-gitignore
+, pkgconfig
+, pyo3-pack
+, python3Packages
+
+, python3
+, libtensorflow
+, openssl
+
+, releaseBuild ? true
+}:
+
+let
+  rustPlatform = callPackage ./nix/rust-nightly.nix {};
+  gitIgnore = callPackage ./nix/gitignore.nix {};
+in rustPlatform.buildRustPackage rec {
+  pname = "sticker";
+  version = "0.1.0";
+
+  src = nix-gitignore.gitignoreSource [".git/"] ./.;
+  cargoSha256 = "1kiqbi64s8bzlyaiq2mk2642zsff7h0cr1yjf5drhizmi1fdvw5y";
+
+  nativeBuildInputs = [ pkgconfig pyo3-pack ];
+
+  buildInputs = [ libtensorflow openssl python3 ];
+
+  installCheckInputs = [ python3Packages.pytest];
+
+  doInstallCheck = true;
+
+  buildPhase = let
+    releaseArg = lib.optionalString releaseBuild "--release";
+  in ''
+    pyo3-pack build ${releaseArg} --manylinux off
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/${python3.sitePackages}"
+    export PYTHONPATH="$out/${python3.sitePackages}:$PYTHONPATH"
+    ${python3.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install \
+        target/wheels/*.whl --no-index --prefix=$out --no-cache --build tmpbuild
+  '';
+
+  checkPhase = ''
+    cargo fmt --all -- --check
+    cargo clippy
+  '';
+
+  installCheckPhase = ''
+    pytest
+  '';
+}

--- a/nix/rust-nightly.nix
+++ b/nix/rust-nightly.nix
@@ -1,0 +1,19 @@
+{ fetchFromGitHub, callPackage, makeRustPlatform }:
+
+let
+  mozillaOverlay = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "nixpkgs-mozilla";
+    rev = "9f35c4b09fd44a77227e79ff0c1b4b6a69dff533";
+    sha256 = "18h0nvh55b5an4gmlgfbvwbyqj91bklf1zymis6lbdh75571qaz0";
+  };
+  mozilla = callPackage "${mozillaOverlay.out}/package-set.nix" {};
+  rustNightly = (mozilla.rustChannelOf { date = "2019-02-07"; channel = "nightly"; }).rust;
+  rustPlatform = makeRustPlatform {
+    cargo = rustNightly;
+    rustc = rustNightly;
+  };
+in makeRustPlatform {
+  cargo = rustNightly;
+  rustc = rustNightly;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,3 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
 
-let
-  danieldk = pkgs.callPackage (builtins.fetchTarball {
-    url = "https://git.sr.ht/~danieldk/nix-packages/archive/709c93a84504d558613bfc2538297ef2c532b890.tar.gz";
-    sha256 = "0jspqxz8yzghn4j3awiqz3f76my8slk3s5ckk3gfzvhq1p0wzp5m";
-  }) {};
-  mozilla = fetchFromGitHub {
-    owner = "mozilla";
-    repo = "nixpkgs-mozilla";
-    rev = "9f35c4b09fd44a77227e79ff0c1b4b6a69dff533";
-    sha256 = "18h0nvh55b5an4gmlgfbvwbyqj91bklf1zymis6lbdh75571qaz0";
-  };
-  rustNightly =
-    with import "${mozillaOverlay.out}/rust-overlay.nix" pkgs pkgs;
-    (rustChannelOf { date = "2019-02-07"; channel = "nightly"; }).rust;
-in stdenv.mkDerivation rec {
-  name = "sticker-env";
-  env = buildEnv { name = name; paths = buildInputs; };
-
-  nativeBuildInputs = [
-    pkgconfig
-    latest.rustChannels.nightly.rust
-    pyo3-pack
-    python3
-    python3Packages.pytest
-  ];
-
-  buildInputs = [
-    curl
-    danieldk.libtensorflow_1_14_0
-    openssl
-  ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
-}
+pkgs.callPackage ./default.nix {}


### PR DESCRIPTION
This makes it much easier to set up dependencies (e.g. libtensorflow)
correctly.