### PR TITLE
Add Tagger type

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  libtensorflow_1_14_0 = callPackage ./nix/libtensorflow.nix {};
+  libtensorflow_1_14_0 = (callPackage ./nix/danieldk.nix {}).libtensorflow_1_14_0;
   rustPlatform = callPackage ./nix/rust-nightly.nix {};
 in rustPlatform.buildRustPackage rec {
   pname = "sticker";

--- a/nix/danieldk.nix
+++ b/nix/danieldk.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
-(callPackage (builtins.fetchTarball {
+callPackage (builtins.fetchTarball {
   url = "https://git.sr.ht/~danieldk/nix-packages/archive/d84cba3b742f94d587191d8c794a7cfc762c1c60.tar.gz";
   sha256 = "1drsg97mfjwmbph8q7f4hpgiyjxvy9ifn83mbpxfkgsa0i7qczdp";
-}) {}).libtensorflow_1_14_0
+}) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ pub use util::ListVec;
 mod config;
 use config::PyConfig;
 
+mod tagger;
+use tagger::PyTagger;
+
 mod sentence;
 pub use sentence::{PySentence, PyToken};
 
@@ -13,6 +16,7 @@ pub use sentence::{PySentence, PyToken};
 #[pymodule]
 fn sticker(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyConfig>()?;
+    m.add_class::<PyTagger>()?;
     m.add_class::<PySentence>()?;
     m.add_class::<PyToken>()?;
 

--- a/src/tagger.rs
+++ b/src/tagger.rs
@@ -1,0 +1,71 @@
+use pyo3::exceptions;
+use pyo3::prelude::*;
+
+use sticker_utils::TaggerWrapper;
+
+use crate::PyConfig;
+use crate::PySentence;
+
+/// Tagger(config)
+/// --
+///
+/// Instances of this class represent taggers. A tagger is constructed
+/// from a configuration.
+#[pyclass(name=Tagger)]
+pub struct PyTagger {
+    inner: TaggerWrapper,
+}
+
+#[pymethods]
+impl PyTagger {
+    #[new]
+    fn __new__(obj: &PyRawObject, config: &PyConfig) -> PyResult<()> {
+        let tagger = TaggerWrapper::new(&config)
+            .map_err(|err| exceptions::IOError::py_err(err.to_string()))?;
+
+        obj.init(PyTagger { inner: tagger });
+
+        Ok(())
+    }
+
+    /// tag_sentence(sentence)
+    /// --
+    ///
+    /// Tag a sentence. The sentences is modified in-place, adding the
+    /// annotations.
+    ///
+    /// Parameters
+    /// ----------
+    /// sentence : Sentence
+    ///     Sentence object to annotate.
+    fn tag_sentence(&self, sentence: &PySentence) -> PyResult<()> {
+        self.tag_sentences(vec![sentence])
+    }
+
+    /// tag_sentences(sentences)
+    /// --
+    ///
+    /// Tag a list of sentences. The sentences are modified in-place, adding
+    /// the annotations.
+    ///
+    /// Parameters
+    /// ----------
+    /// sentences : list
+    ///     List of Sentence objects to annotate.
+    fn tag_sentences(&self, sentences: Vec<&PySentence>) -> PyResult<()> {
+        // We need borrowed_sents to exist as long as sents, since the
+        // lifetimes of sentences are bound to RefMut returned by
+        // PySentence::inner.
+        let mut borrowed_sents = sentences
+            .into_iter()
+            .map(|sent| sent.inner())
+            .collect::<Vec<_>>();
+        let mut sents = borrowed_sents
+            .iter_mut()
+            .map(|sent| &mut **sent)
+            .collect::<Vec<_>>();
+        self.inner
+            .tag_sentences(&mut sents)
+            .map_err(|err| exceptions::RuntimeError::py_err(err.to_string()))
+    }
+}

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,18 @@
+{
+  callPackage
+, runCommand
+
+, python3Packages
+
+, releaseBuild ? true
+}:
+
+let
+  sticker-python = callPackage ./default.nix { inherit releaseBuild; };
+  de-pos-ud = (callPackage ./nix/danieldk.nix {}).stickerModels.de-pos-ud;
+in runCommand "test-tagger" {
+  nativeBuildInputs = [ python3Packages.pytest sticker-python ];
+} ''
+  pytest --tagger_model ${de-pos-ud}/share/sticker/models/de-pos-ud/sticker.conf ${sticker-python.src}
+  touch $out
+''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+from sticker import Config, Tagger
+
+def pytest_addoption(parser):
+    parser.addoption("--tagger_model", action="store", default=None)
+
+def pytest_generate_tests(metafunc):
+    opt_tagger_model = metafunc.config.option.tagger_model
+
+    if 'tagger_model_file' in metafunc.fixturenames:
+        if opt_tagger_model is not None:
+            metafunc.parametrize("tagger_model_file", [opt_tagger_model])
+        else:
+            metafunc.parametrize("tagger_model_file", [])
+
+@pytest.fixture
+def tagger_model(tagger_model_file):
+    config = Config(tagger_model_file)
+    yield Tagger(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from sticker import Config, Tagger
 
@@ -17,3 +19,7 @@ def pytest_generate_tests(metafunc):
 def tagger_model(tagger_model_file):
     config = Config(tagger_model_file)
     yield Tagger(config)
+
+@pytest.fixture
+def tests_root():
+    yield os.path.dirname(__file__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,15 @@
+import os
+
 import pytest
 from sticker import Config, Sentence
 
-def test_config():
-    Config("tests/sticker.conf")
+def test_config(tests_root):
+    Config(os.path.join(tests_root, "sticker.conf"))
 
-def test_bogus_config():
+def test_bogus_config(tests_root):
     with pytest.raises(ValueError):
-        Config("tests/bogus.conf")
+        Config(os.path.join(tests_root, "bogus.conf"))
 
-def test_missing_config():
+def test_missing_config(tests_root):
     with pytest.raises(IOError):
-        Config("tests/nonexistant.conf")
+        Config(os.path.join(tests_root, "nonexistant.conf"))

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -1,0 +1,13 @@
+from sticker import Config, Sentence, Tagger
+
+def test_tag_sentence(tagger_model):
+    sent = Sentence("Chandrayaan-2 ist eine Mondsonde .".split(" "))
+    tagger_model.tag_sentence(sent)
+
+    # Fixme: after Sentence supports iteration.
+    assert sent[0].pos is None
+    assert sent[1].pos == "PROPN-NE"
+    assert sent[2].pos == "AUX-VAFIN"
+    assert sent[3].pos == "DET-ART"
+    assert sent[4].pos == "NOUN-NN"
+    assert sent[5].pos == "PUNCT-$."


### PR DESCRIPTION
Again no `__repr__` or `__str__`, since `TaggerWrapper` is opaque. We could expose more information in `sticker` in the future (e.g., it would be nice to expose the layer that the `TaggerWrapper` and thus `Tagger` annotates).