### PR TITLE
Add Labeler type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,13 @@ impl PyConfig {
     }
 
     #[getter]
+    fn get_labeler(&self) -> PyLabeler {
+        PyLabeler {
+            config: self.inner.clone(),
+        }
+    }
+
+    #[getter]
     fn get_model(&self) -> PyModel {
         PyModel {
             config: self.inner.clone(),
@@ -122,5 +129,40 @@ impl PyModel {
 impl PyObjectProtocol for PyModel {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{:?}", self.config.borrow().model))
+    }
+}
+
+#[pyclass(name=Labeler)]
+pub struct PyLabeler {
+    config: Rc<RefCell<Config>>,
+}
+
+#[pymethods]
+impl PyLabeler {
+    #[getter]
+    fn get_labels(&self) -> String {
+        self.config.borrow().labeler.labels.clone()
+    }
+
+    #[getter]
+    fn get_read_ahead(&self) -> usize {
+        self.config.borrow().labeler.read_ahead
+    }
+
+    #[setter]
+    fn set_labels(&self, labels: &str) {
+        self.config.borrow_mut().labeler.labels = labels.to_owned()
+    }
+
+    #[setter]
+    fn set_read_ahead(&self, read_ahead: usize) {
+        self.config.borrow_mut().labeler.read_ahead = read_ahead
+    }
+}
+
+#[pyproto]
+impl PyObjectProtocol for PyLabeler {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{:?}", self.config.borrow().labeler))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod util;
 pub use util::ListVec;
 
 mod config;
-use config::{PyConfig, PyModel};
+use config::{PyConfig, PyLabeler, PyModel};
 
 mod tagger;
 use tagger::PyTagger;
@@ -16,6 +16,7 @@ pub use sentence::{PySentence, PyToken};
 #[pymodule]
 fn sticker(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyConfig>()?;
+    m.add_class::<PyLabeler>()?;
     m.add_class::<PyModel>()?;
     m.add_class::<PyTagger>()?;
     m.add_class::<PySentence>()?;

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,18 @@ def test_missing_config(tests_root):
     with pytest.raises(IOError):
         Config(os.path.join(tests_root, "nonexistant.conf"))
 
+def test_labeler(tests_root):
+    config = Config(os.path.join(tests_root, "sticker.conf"))
+
+    assert config.labeler.labels.endswith("sticker.labels")
+    assert config.labeler.read_ahead == 10
+
+    config.labeler.labels = "another.labels"
+    config.labeler.read_ahead = 10
+
+    assert config.labeler.labels == "another.labels"
+    assert config.labeler.read_ahead == 10
+
 
 def test_model(tests_root):
     config = Config(os.path.join(tests_root, "sticker.conf"))


### PR DESCRIPTION
The `labeler_type` field is not yet exposed. There is no direct translation in pyo3 from Rust enums to Python enums. I still have to think a bit about whether I want some big class to represent both types (meh) or make a type hierarchy where both variants are a subclass of some superclass (meh).